### PR TITLE
[Merge] 금일 백엔드에 대한 프론트 요구사항 취합 후 구현

### DIFF
--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/api/RecommendationApiController.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/api/RecommendationApiController.java
@@ -26,6 +26,11 @@ public class RecommendationApiController {
         return recommendationService.recommendProblem(authentication);
     }
 
+    @GetMapping("/today")
+    public BasicResponseDto<?> todayRecommendedProblemList(Authentication authentication) {
+        return recommendationService.getTodayRecommendedProblemListByUser(authentication);
+    }
+
     @PostMapping
     public BasicResponseDto<?> problemCheck(Authentication authentication, @RequestBody CheckSolvedRequestDto checkSolvedRequestDto) throws IOException {
         Long problemId = checkSolvedRequestDto.getProblemId();

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/api/UserApiController.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/api/UserApiController.java
@@ -3,7 +3,6 @@ package com.khk.backjoonrecommender.controller.api;
 import com.khk.backjoonrecommender.controller.dto.request.RivalSearchRequestDto;
 import com.khk.backjoonrecommender.controller.dto.request.UserRegisterRequestDto;
 import com.khk.backjoonrecommender.controller.dto.response.*;
-import com.khk.backjoonrecommender.entity.Problem;
 import com.khk.backjoonrecommender.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +28,7 @@ public class UserApiController {
 	}
 
 	@GetMapping("/{userId}/solved")
-	public BasicResponseDto<List<Problem>> solvedProblemList(@PathVariable Long userId) {
+	public BasicResponseDto<List<SolvedProblemListResponseDto>> solvedProblemList(@PathVariable Long userId) {
 		return userService.getSolvedProblemList(userId);
 	}
 

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/dto/response/RecommendProblemResponseDto.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/dto/response/RecommendProblemResponseDto.java
@@ -1,0 +1,27 @@
+package com.khk.backjoonrecommender.controller.dto.response;
+
+import com.khk.backjoonrecommender.entity.Problem;
+import com.khk.backjoonrecommender.entity.SolveType;
+import com.khk.backjoonrecommender.entity.TriedProblem;
+import com.khk.backjoonrecommender.entity.User;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class RecommendProblemResponseDto {
+	private Problem problem;
+	private String username;
+	private String baekJoonId;
+	private LocalDate recommendedDate;
+	private SolveType isSolved;
+
+	public RecommendProblemResponseDto(TriedProblem triedProblem) {
+		User user = triedProblem.getUser();
+		this.problem = triedProblem.getProblem();
+		this.username = user.getUsername();
+		this.baekJoonId = user.getBaekJoonId();
+		this.recommendedDate = triedProblem.getRecommendedDate();
+		this.isSolved = triedProblem.getIsSolved();
+	}
+}

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/dto/response/SolvedProblemListResponseDto.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/controller/dto/response/SolvedProblemListResponseDto.java
@@ -1,0 +1,27 @@
+package com.khk.backjoonrecommender.controller.dto.response;
+
+import com.khk.backjoonrecommender.entity.Problem;
+import com.khk.backjoonrecommender.entity.SolveType;
+import com.khk.backjoonrecommender.entity.TriedProblem;
+import com.khk.backjoonrecommender.entity.User;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SolvedProblemListResponseDto {
+	private Problem problem;
+	private String username;
+	private String baekJoonId;
+	private SolveType isSolved;
+	private LocalDateTime solvedDate;
+
+	public SolvedProblemListResponseDto(TriedProblem triedProblem) {
+		User solver = triedProblem.getUser();
+		this.problem = triedProblem.getProblem();
+		this.username = solver.getUsername();
+		this.baekJoonId = solver.getBaekJoonId();
+		this.isSolved = triedProblem.getIsSolved();
+		this.solvedDate = getSolvedDate();
+	}
+}

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/SolveType.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/SolveType.java
@@ -3,5 +3,6 @@ package com.khk.backjoonrecommender.entity;
 public enum SolveType {
     FAIL,
     PARTIAL,
+    SOLVING,
     PASS
 }

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
@@ -39,7 +39,14 @@ public class TriedProblem {
 		return TODAY.equals(this.recommendedDate);
 	}
 
+	public boolean isSameProblem(Long problemId) {
+		return this.getProblem().getId().equals(problemId);
+	}
+
 	public void updateSolvedStatus(SolveType solveType) {
+		if (solveType.equals(SolveType.PASS)) {
+			this.solvedDate = LocalDateTime.now();
+		}
 		this.isSolved = solveType;
 	}
 }

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -27,6 +28,7 @@ public class TriedProblem {
 	@Enumerated(EnumType.STRING)
 	private SolveType isSolved;
 	private LocalDateTime solvedDate;
+	private LocalDate recommendedDate;
 
 	public boolean solved() {
 		return this.isSolved.equals(SolveType.PASS);

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/TriedProblem.java
@@ -34,6 +34,11 @@ public class TriedProblem {
 		return this.isSolved.equals(SolveType.PASS);
 	}
 
+	public boolean isRecommendedToday() {
+		final LocalDate TODAY = LocalDate.now();
+		return TODAY.equals(this.recommendedDate);
+	}
+
 	public void updateSolvedStatus(SolveType solveType) {
 		this.isSolved = solveType;
 	}

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/User.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/entity/User.java
@@ -1,5 +1,6 @@
 package com.khk.backjoonrecommender.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.khk.backjoonrecommender.controller.dto.request.UserRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +44,7 @@ public class User {
     @JoinColumn(name = "setting_id")
     private Setting setting;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<TriedProblem> triedProblemList = new ArrayList<>();
 

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/RecommendationService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/RecommendationService.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.Authentication;
 import java.io.IOException;
 
 public interface RecommendationService {
-    public BasicResponseDto<?> recommendProblem(Authentication authentication) throws IOException;
+    public BasicResponseDto<?> recommendProblem(Authentication authentication);
 
     public BasicResponseDto<?> checkProblemIfSolved(Authentication authentication, Long problemId) throws IOException;
 

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/RecommendationService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/RecommendationService.java
@@ -2,16 +2,20 @@ package com.khk.backjoonrecommender.service;
 
 import com.khk.backjoonrecommender.controller.dto.request.SettingRequestDto;
 import com.khk.backjoonrecommender.controller.dto.response.BasicResponseDto;
+import com.khk.backjoonrecommender.controller.dto.response.RecommendProblemResponseDto;
 import org.springframework.security.core.Authentication;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface RecommendationService {
-    public BasicResponseDto<?> recommendProblem(Authentication authentication);
+    BasicResponseDto<?> recommendProblem(Authentication authentication);
 
-    public BasicResponseDto<?> checkProblemIfSolved(Authentication authentication, Long problemId) throws IOException;
+    BasicResponseDto<List<RecommendProblemResponseDto>> getTodayRecommendedProblemListByUser(Authentication authentication);
 
-    public BasicResponseDto<?> findAdditionalProblem(Authentication authentication, SettingRequestDto settingRequestDto) throws IOException;
+    BasicResponseDto<?> checkProblemIfSolved(Authentication authentication, Long problemId) throws IOException;
 
-    public BasicResponseDto<?> reloadProblem(Authentication authentication) throws IOException;
+    BasicResponseDto<?> findAdditionalProblem(Authentication authentication, SettingRequestDto settingRequestDto) throws IOException;
+
+    BasicResponseDto<?> reloadProblem(Authentication authentication) throws IOException;
 }

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/UserService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/UserService.java
@@ -3,7 +3,6 @@ package com.khk.backjoonrecommender.service;
 import com.khk.backjoonrecommender.controller.dto.request.RivalSearchRequestDto;
 import com.khk.backjoonrecommender.controller.dto.request.UserRegisterRequestDto;
 import com.khk.backjoonrecommender.controller.dto.response.*;
-import com.khk.backjoonrecommender.entity.Problem;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
 
@@ -25,7 +24,7 @@ public interface UserService {
 
 	BasicResponseDto<RivalSearchResponseDto> findRival(RivalSearchRequestDto rivalSearchRequestDto);
 
-	BasicResponseDto<List<Problem>> getSolvedProblemList(Long userId);
+	BasicResponseDto<List<SolvedProblemListResponseDto>> getSolvedProblemList(Long userId);
 
 	BasicResponseDto<?> deleteUserInfo(Authentication authentication);
 }

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/BasicUserService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/BasicUserService.java
@@ -8,13 +8,17 @@ import com.khk.backjoonrecommender.controller.dto.response.*;
 import com.khk.backjoonrecommender.entity.Problem;
 import com.khk.backjoonrecommender.entity.Rival;
 import com.khk.backjoonrecommender.entity.Setting;
+import com.khk.backjoonrecommender.entity.SolveType;
 import com.khk.backjoonrecommender.entity.TriedProblem;
 import com.khk.backjoonrecommender.entity.User;
 import com.khk.backjoonrecommender.exception.BaekJoonIdNotFoundException;
 import com.khk.backjoonrecommender.exception.handler.AlreadyRegisteredException;
+import com.khk.backjoonrecommender.repository.ProblemRepository;
 import com.khk.backjoonrecommender.repository.RivalRepository;
 import com.khk.backjoonrecommender.repository.SettingRepository;
+import com.khk.backjoonrecommender.repository.TriedProblemRepository;
 import com.khk.backjoonrecommender.repository.UserRepository;
+import com.khk.backjoonrecommender.service.BaekJoonApiService;
 import com.khk.backjoonrecommender.service.UserService;
 import com.khk.backjoonrecommender.service.ValidationService;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -39,7 +45,10 @@ import static com.khk.backjoonrecommender.common.ResponseCodeMessage.*;
 @Service
 public class BasicUserService implements UserService {
 	private final ValidationService validationService;
+	private final BaekJoonApiService baekJoonApiService;
 	private final UserRepository userRepository;
+	private final TriedProblemRepository triedProblemRepository;
+	private final ProblemRepository problemRepository;
 	private final RivalRepository rivalRepository;
 	private final SettingRepository settingRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
@@ -114,6 +123,8 @@ public class BasicUserService implements UserService {
 		user.resetReloadCount();
 		userRepository.save(user);
 
+		saveSolvedProblemFromBaekJoonToServer(user);
+
 		BasicResponseDto<User> responseDto = new BasicResponseDto<>();
 		responseDto.setCode(SUCCESS);
 		responseDto.setMessage(REGISTER_SUCCESS);
@@ -121,6 +132,39 @@ public class BasicUserService implements UserService {
 		log.info("user {} is created", user.getUsername());
 
 		return responseDto;
+	}
+
+	/**
+	 * 회원가입 시 사용자의 백준 아이디가 푼 문제 전체를 Server 에 반영
+	 * @param user 사용자 Entity
+	 * @throws IOException 백준 사이트 크롤링 Exception
+	 */
+	private void saveSolvedProblemFromBaekJoonToServer(User user) throws IOException {
+		String baekJoonId = user.getBaekJoonId();
+		List<Long> userSolvedProblemIdList = baekJoonApiService.getSolvedProblemIdListByBaekJoonId(baekJoonId);
+		List<Optional<Problem>> userSolvedProblemList = userSolvedProblemIdList.stream()
+				.map(problemRepository::findById)
+				.collect(Collectors.toList());
+
+		userSolvedProblemList.stream()
+				.filter(Optional::isPresent)
+				.forEach(solvedProblem -> saveTriedProblemToServer(user, solvedProblem.get()));
+	}
+
+	/**
+	 * 사용자가 푼 문제를 다 : 다 매핑으로 TriedProblem 으로 Server 에 저장
+	 * @param user 사용자 Entity
+	 * @param solvedProblem 사용자가 푼 문제 객체
+	 */
+	private void saveTriedProblemToServer(User user, Problem solvedProblem) {
+		TriedProblem passedProblem = TriedProblem.builder()
+				.user(user)
+				.problem(solvedProblem)
+				.solvedDate(LocalDateTime.of(2022, Month.JUNE, 25, 0, 0))
+				.isSolved(SolveType.PASS)
+				.build();
+		log.info("user id={} solved problem no.{}", user.getId(), solvedProblem.getId());
+		triedProblemRepository.save(passedProblem);
 	}
 
 	@Override

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/BasicUserService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/BasicUserService.java
@@ -190,14 +190,14 @@ public class BasicUserService implements UserService {
 	}
 
 	@Override
-	public BasicResponseDto<List<Problem>> getSolvedProblemList(Long userId) {
+	public BasicResponseDto<List<SolvedProblemListResponseDto>> getSolvedProblemList(Long userId) {
 		Optional<User> findResult = userRepository.findById(userId);
 		log.info("get solved problem list user id = {}", userId);
 		if (findResult.isPresent()) {
 			User user = findResult.get();
-			List<Problem> solvedProblemList = user.getTriedProblemList().stream()
+			List<SolvedProblemListResponseDto> solvedProblemList = user.getTriedProblemList().stream()
 					.filter(TriedProblem::solved)
-					.map(TriedProblem::getProblem)
+					.map(SolvedProblemListResponseDto::new)
 					.collect(Collectors.toList());
 			log.info("success to get solved problem list");
 

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/RecommendationBasicService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/RecommendationBasicService.java
@@ -2,6 +2,7 @@ package com.khk.backjoonrecommender.service.impl;
 
 import com.khk.backjoonrecommender.controller.dto.request.SettingRequestDto;
 import com.khk.backjoonrecommender.controller.dto.response.BasicResponseDto;
+import com.khk.backjoonrecommender.controller.dto.response.RecommendProblemResponseDto;
 import com.khk.backjoonrecommender.entity.Option;
 import com.khk.backjoonrecommender.entity.Problem;
 import com.khk.backjoonrecommender.entity.Setting;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -58,10 +60,19 @@ public class RecommendationBasicService implements RecommendationService {
 		List<Problem> filteredProblemList = getFilteredProblemList(levelFilter, tagFilter, userSolvedFilter);
 
 		Problem recommendedProblem = getRandomProblem(filteredProblemList);
-		BasicResponseDto<Problem> result = new BasicResponseDto<>();
+
+		TriedProblem todayRecommended = TriedProblem.builder()
+				.user(loginUser)
+				.problem(recommendedProblem)
+				.isSolved(SolveType.SOLVING)
+				.recommendedDate(LocalDate.now())
+				.build();
+		triedProblemRepository.save(todayRecommended);
+
+		BasicResponseDto<RecommendProblemResponseDto> result = new BasicResponseDto<>();
 		result.setCode(200);
 		result.setMessage("success to recommend baek joon problem");
-		result.setData(recommendedProblem);
+		result.setData(new RecommendProblemResponseDto(todayRecommended));
 
 		return result;
 	}

--- a/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/RecommendationBasicService.java
+++ b/server/backjoon-recommender/src/main/java/com/khk/backjoonrecommender/service/impl/RecommendationBasicService.java
@@ -77,6 +77,28 @@ public class RecommendationBasicService implements RecommendationService {
 		return result;
 	}
 
+	@Override
+	public BasicResponseDto<List<RecommendProblemResponseDto>> getTodayRecommendedProblemListByUser(Authentication authentication) {
+		User loginUser = getLoginUser(authentication);
+		List<TriedProblem> triedProblemList = loginUser.getTriedProblemList();
+
+		List<RecommendProblemResponseDto> todayRecommendedList = triedProblemList.stream()
+				.filter(TriedProblem::isRecommendedToday)
+				.map(RecommendProblemResponseDto::new)
+				.collect(Collectors.toList());
+
+		if (todayRecommendedList.isEmpty()) {
+			return new BasicResponseDto<>(400, "No recommended today", null);
+		}
+
+		BasicResponseDto<List<RecommendProblemResponseDto>> response = new BasicResponseDto<>();
+		response.setCode(200);
+		response.setMessage("today recommended problem list");
+		response.setData(todayRecommendedList);
+
+		return response;
+	}
+
 	/**
 	 * Server 로 부터, 로그인된 사용자가 푼 문제 번호 목록 가져와서 Set 으로 반환
 	 * @param loginUser 사용자 Entity


### PR DESCRIPTION
문제를 추천해주는 순간, 오늘의 추천 목록에 저장하기. => 사용자 entity에 ‘오늘 추천받은 문제 리스트’ 정보를 저장하여 관리하기

문제가 풀렸는지 판단할 때, 풀렸다면 DB에서 TriedProblem 꺼내서 isSolved수정해주도록 변경

오늘 추천받은 문제 리스트 조회 API 개발 

회원가입시 이전까지 백준에 solved 된 문제들 tried_problem db에 저장하기

refactoring
GET solved problem list 기능을 2개로 나누기. DB에서 가져오기 + 백준 사이트에서 가져오기